### PR TITLE
Add option to save documents by merging them with existing ones

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,7 @@ Available parameters (in settings.py)
    ELASTICSEARCH_AUTH  - optional field, set to 'NTLM' to use NTLM authentification
    ELASTICSEARCH_USERNAME - optional field, set to 'DOMAIN\username', only used with NLTM authentification
    ELASTICSEARCH_PASSWORD - optional field, set to your 'password', only used with NLTM authentification
+   ELASTICSEARCH_MERGE - optional field, if set to True new documents will be merged with existing ones with the same ID using Elastic's update + upsert
 
    ELASTICSEARCH_CA - optional settings to if es servers require custom CA files.
    Example:

--- a/scrapyelasticsearch/scrapyelasticsearch.py
+++ b/scrapyelasticsearch/scrapyelasticsearch.py
@@ -45,6 +45,11 @@ class ElasticSearchPipeline(object):
         for required_setting in required_settings:
             validate_setting(required_setting)
 
+        if 'ELASTICSEARCH_MERGE' in settings and settings['ELASTICSEARCH_MERGE']:
+            if 'ELASTICSEARCH_UNIQ_KEY' not in settings:
+                raise InvalidSettingsException('ELASTICSEARCH_UNIQ_KEY is required when using ' + \
+                                               'ELASTICSEARCH_MERGE, but it is not defined in settings.py')
+
     @classmethod
     def init_es_client(cls, crawler_settings):
         auth_type = crawler_settings.get('ELASTICSEARCH_AUTH')
@@ -125,11 +130,23 @@ class ElasticSearchPipeline(object):
         elif index_suffix_key:
             index_name += "-" + index_suffix_key
 
-        index_action = {
-            '_index': index_name,
-            '_type': self.settings['ELASTICSEARCH_TYPE'],
-            '_source': dict(item)
-        }
+        item_type = self.settings['ELASTICSEARCH_TYPE']
+        item_dict = dict(item)
+
+        if self.settings['ELASTICSEARCH_MERGE'] == True:
+            index_action = {
+                '_op_type': 'update',
+                '_index': index_name,
+                '_type': item_type,
+                'doc': item_dict,
+                'upsert': item_dict
+            }
+        else:
+            index_action = {
+                '_index': index_name,
+                '_type': item_type,
+                '_source': item_dict
+            }
 
         if self.settings['ELASTICSEARCH_UNIQ_KEY'] is not None:
             item_id = self.get_id(item)


### PR DESCRIPTION
This adds a new boolean option called ELASTICSEARCH_MERGE

When set to True documents are saved using an update. The item is sent both as the partial doc for the update, as well as the upsert which is used when the element doesn't already exist. 

This makes it easier to split crawling tasks that involve multiple requests for the same item, without having to pass the item along in the meta dict for the next request. It also allows different crawlers to contribute to the same document in separate crawl runs. 