### PR TITLE
Added possibility to use api-key for authentification.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,8 @@ Available parameters (in settings.py)
    ELASTICSEARCH_USERNAME - optional field, set to 'DOMAIN\username', only used with NLTM authentification
    ELASTICSEARCH_PASSWORD - optional field, set to your 'password', only used with NLTM authentification
 
+   ELASTICSEARCH_API_KEY_ID - optional field, set to api-key id, only used for api-key authentification.
+   ELASTICSEARCH_API_KEY_VALUE - optional field, set to api-key value, only used for api-key authentification.
    ELASTICSEARCH_CA - optional settings to if es servers require custom CA files.
    Example:
    ELASTICSEARCH_CA = {

--- a/scrapyelasticsearch/scrapyelasticsearch.py
+++ b/scrapyelasticsearch/scrapyelasticsearch.py
@@ -70,6 +70,12 @@ class ElasticSearchPipeline(object):
         if 'ELASTICSEARCH_USERNAME' in crawler_settings and 'ELASTICSEARCH_PASSWORD' in crawler_settings:
             es_settings['http_auth'] = (crawler_settings['ELASTICSEARCH_USERNAME'], crawler_settings['ELASTICSEARCH_PASSWORD'])
 
+        if 'ELASTICSEARCH_API_KEY_VALUE' in crawler_settings and 'ELASTICSEARCH_API_KEY_ID' in crawler_settings:
+            es_settings['api_key'] = (
+                crawler_settings['ELASTICSEARCH_API_KEY_VALUE'],
+                crawler_settings['ELASTICSEARCH_API_KEY_ID']
+            )
+
         if 'ELASTICSEARCH_CA' in crawler_settings:
             import certifi
             es_settings['port'] = 443


### PR DESCRIPTION
Hi!
Great repo. I added the possibility to use authentification by api-key. Documentation about this can be found here:
https://elasticsearch-py.readthedocs.io/en/master/#api-key-authentication
https://www.elastic.co/guide/en/kibana/master/api-keys.html

The two new parameters were also added to the readme.
Cheers,
Julian

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
